### PR TITLE
Fix syntax error in style.css

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -43,7 +43,7 @@ html {
 body {
     color: #747369d4;
     background: #111114;
-    line-height: 1.57
+    line-height: 1.57;
     font-size: 1.0rem;
     font-family: -apple-system, BlinkMacSystemFont, YakuHanJP, Hiragino Kaku Gothic ProN, Meiryo, sans-serif;
 }


### PR DESCRIPTION
body line-height lacked a semicolon. This caused body text to be vertically spaced too tightly. As a result, `<code>` text looked overly spaced.